### PR TITLE
Retrieve invoice data by invoice or customer

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,161 @@
-# DevelopmentCode
+# Oracle ADW ORDS API Solution for OEINVH
+
+## Problem Statement
+You need to create a REST API endpoint in Oracle ADW using ORDS that can:
+1. Return all records when no parameters are passed
+2. Filter by `invuniq` when that parameter is provided
+3. Filter by `customer` when that parameter is provided
+
+## Issue with Original Query
+The original query used OR logic:
+```sql
+SELECT * FROM SFLDAT.OEINVH 
+WHERE NVL(NULLIF(:invuniq, ''), invuniq) = invuniq 
+   OR NVL(NULLIF(:customer, ''), customer) = customer
+```
+
+This would return records matching EITHER condition, not the intended behavior.
+
+## Solution
+The corrected query uses AND logic with proper NULL handling:
+```sql
+SELECT * FROM SFLDAT.OEINVH 
+WHERE (:invuniq IS NULL OR :invuniq = '' OR invuniq = :invuniq)
+  AND (:customer IS NULL OR :customer = '' OR customer = :customer)
+```
+
+## How It Works
+- When no parameters are passed: Both conditions evaluate to TRUE, returning all records
+- When `invuniq` is provided: Only records matching that `invuniq` are returned
+- When `customer` is provided: Only records matching that `customer` are returned
+- When both are provided: Only records matching both conditions are returned
+
+## API Endpoints
+
+### Base URL
+`https://testitrack.servicefoods.co.nz/ords/salesforceext/sfldat/oeinvh`
+
+### Usage Examples
+
+1. **Get all records:**
+   ```
+   GET https://testitrack.servicefoods.co.nz/ords/salesforceext/sfldat/oeinvh
+   ```
+
+2. **Filter by invuniq:**
+   ```
+   GET https://testitrack.servicefoods.co.nz/ords/salesforceext/sfldat/oeinvh?invuniq=YOUR_INVUNIQ_VALUE
+   ```
+
+3. **Filter by customer:**
+   ```
+   GET https://testitrack.servicefoods.co.nz/ords/salesforceext/sfldat/oeinvh?customer=YOUR_CUSTOMER_VALUE
+   ```
+
+4. **Filter by both parameters:**
+   ```
+   GET https://testitrack.servicefoods.co.nz/ords/salesforceext/sfldat/oeinvh?invuniq=YOUR_INVUNIQ_VALUE&customer=YOUR_CUSTOMER_VALUE
+   ```
+
+## Setup Instructions
+
+1. **Run the setup script:**
+   ```sql
+   @ords_oeinvh_setup.sql
+   ```
+
+2. **Grant necessary privileges (as DBA or schema owner):**
+   ```sql
+   GRANT SELECT ON SFLDAT.OEINVH TO ORDS_PUBLIC_USER;
+   ```
+
+3. **Verify the configuration:**
+   ```sql
+   SELECT 
+       m.module_name,
+       t.pattern,
+       h.method,
+       h.source_type,
+       h.source
+   FROM user_ords_modules m
+   JOIN user_ords_templates t ON m.module_id = t.module_id
+   JOIN user_ords_handlers h ON t.template_id = h.template_id
+   WHERE m.module_name = 'salesforceext'
+     AND t.pattern = 'sfldat/oeinvh';
+   ```
+
+## Alternative Query Approaches
+
+### Option 1: Using CASE WHEN
+```sql
+SELECT * 
+FROM SFLDAT.OEINVH 
+WHERE (CASE 
+    WHEN :invuniq IS NOT NULL AND :invuniq != '' THEN 
+        CASE WHEN invuniq = :invuniq THEN 1 ELSE 0 END
+    WHEN :customer IS NOT NULL AND :customer != '' THEN 
+        CASE WHEN customer = :customer THEN 1 ELSE 0 END
+    ELSE 1
+END) = 1;
+```
+
+### Option 2: Using NVL (Simplified)
+```sql
+SELECT * 
+FROM SFLDAT.OEINVH 
+WHERE (:invuniq IS NULL OR :invuniq = '' OR invuniq = :invuniq)
+  AND (:customer IS NULL OR :customer = '' OR customer = :customer);
+```
+
+## Response Format
+The API will return JSON in the following format:
+```json
+{
+  "items": [
+    {
+      "invuniq": "value1",
+      "customer": "customer1",
+      // ... other fields
+    },
+    {
+      "invuniq": "value2", 
+      "customer": "customer2",
+      // ... other fields
+    }
+  ],
+  "hasMore": false,
+  "limit": 25,
+  "offset": 0,
+  "count": 2,
+  "links": [
+    {
+      "rel": "self",
+      "href": "https://testitrack.servicefoods.co.nz/ords/salesforceext/sfldat/oeinvh"
+    }
+  ]
+}
+```
+
+## Troubleshooting
+
+1. **Check ORDS status:**
+   ```sql
+   SELECT * FROM user_ords_modules WHERE module_name = 'salesforceext';
+   ```
+
+2. **Verify table access:**
+   ```sql
+   SELECT COUNT(*) FROM SFLDAT.OEINVH;
+   ```
+
+3. **Test with specific values:**
+   ```sql
+   SELECT * FROM SFLDAT.OEINVH 
+   WHERE (:invuniq IS NULL OR :invuniq = '' OR invuniq = :invuniq)
+     AND (:customer IS NULL OR :customer = '' OR customer = :customer);
+   ```
+
+## Files Included
+- `ords_oeinvh_setup.sql` - Complete ORDS setup script
+- `ords_api_solution.sql` - Query solutions and examples
+- `README.md` - This documentation

--- a/fixed_oeshih_query.sql
+++ b/fixed_oeshih_query.sql
@@ -1,0 +1,138 @@
+-- Fixed OESHIH query to handle ORA-01722 data type conversion errors
+
+-- PROBLEM: ORA-01722 occurs when comparing string input with numeric columns
+-- Columns like shiuniq, shinumber, lastinvnum are likely numeric
+-- When :input is a string, Oracle can't convert it to number for comparison
+
+-- SOLUTION 1: Convert numeric columns to strings for comparison (SAFEST)
+SELECT * 
+FROM SFLDAT.OESHIH
+WHERE (:input IS NULL OR :input = '')
+   OR TO_CHAR(shiuniq) = :input
+   OR TO_CHAR(shinumber) = :input
+   OR customer = :input
+   OR ponumber = :input
+   OR TO_CHAR(lastinvnum) = :input
+   OR UPPER(bilname) LIKE UPPER('%' || :input || '%')
+
+-- SOLUTION 2: Use CASE WHEN to handle data type conversion safely
+SELECT * 
+FROM SFLDAT.OESHIH
+WHERE (:input IS NULL OR :input = '')
+   OR CASE 
+       WHEN REGEXP_LIKE(:input, '^[0-9]+$') THEN
+           -- Input is numeric, compare with numeric fields
+           shiuniq = TO_NUMBER(:input) 
+           OR shinumber = TO_NUMBER(:input) 
+           OR lastinvnum = TO_NUMBER(:input)
+       ELSE
+           -- Input is string, compare with string fields
+           customer = :input 
+           OR ponumber = :input 
+           OR UPPER(bilname) LIKE UPPER('%' || :input || '%')
+       END
+
+-- SOLUTION 3: Separate numeric and string comparisons (RECOMMENDED)
+SELECT * 
+FROM SFLDAT.OESHIH
+WHERE (:input IS NULL OR :input = '')
+   OR (
+       -- Try numeric comparison first (if input looks like a number)
+       CASE 
+           WHEN REGEXP_LIKE(:input, '^[0-9]+$') THEN
+               shiuniq = TO_NUMBER(:input) 
+               OR shinumber = TO_NUMBER(:input) 
+               OR lastinvnum = TO_NUMBER(:input)
+           ELSE 0
+       END = 1
+   )
+   OR (
+       -- String comparisons
+       customer = :input 
+       OR ponumber = :input 
+       OR UPPER(bilname) LIKE UPPER('%' || :input || '%')
+   )
+
+-- SOLUTION 4: Use NVL to handle NULL conversions safely
+SELECT * 
+FROM SFLDAT.OESHIH
+WHERE (:input IS NULL OR :input = '')
+   OR TO_CHAR(NVL(shiuniq, 0)) = :input
+   OR TO_CHAR(NVL(shinumber, 0)) = :input
+   OR customer = :input
+   OR ponumber = :input
+   OR TO_CHAR(NVL(lastinvnum, 0)) = :input
+   OR UPPER(bilname) LIKE UPPER('%' || :input || '%')
+
+-- SOLUTION 5: Most robust - handle all possible data types
+SELECT * 
+FROM SFLDAT.OESHIH
+WHERE (:input IS NULL OR :input = '')
+   OR (
+       -- Try to convert to number and compare with numeric fields
+       CASE 
+           WHEN REGEXP_LIKE(:input, '^[0-9]+$') THEN
+               CASE 
+                   WHEN shiuniq = TO_NUMBER(:input) THEN 1
+                   WHEN shinumber = TO_NUMBER(:input) THEN 1
+                   WHEN lastinvnum = TO_NUMBER(:input) THEN 1
+                   ELSE 0
+               END
+           ELSE 0
+       END = 1
+   )
+   OR (
+       -- String comparisons
+       customer = :input 
+       OR ponumber = :input 
+       OR UPPER(bilname) LIKE UPPER('%' || :input || '%')
+   )
+
+-- RECOMMENDED VERSION FOR ORDS API:
+-- This handles all data types safely and prevents ORA-01722
+SELECT * 
+FROM SFLDAT.OESHIH
+WHERE (:input IS NULL OR :input = '')
+   OR TO_CHAR(shiuniq) = :input
+   OR TO_CHAR(shinumber) = :input
+   OR customer = :input
+   OR ponumber = :input
+   OR TO_CHAR(lastinvnum) = :input
+   OR UPPER(bilname) LIKE UPPER('%' || :input || '%')
+
+-- For ORDS handler, use this:
+/*
+BEGIN
+    ORDS.DEFINE_HANDLER(
+        p_module_name    => 'salesforceext',
+        p_pattern        => 'sfldat/oeshih',
+        p_method         => 'GET',
+        p_source_type    => ORDS.source_type_collection_feed,
+        p_source         => 'SELECT * FROM SFLDAT.OESHIH WHERE (:input IS NULL OR :input = '''') OR TO_CHAR(shiuniq) = :input OR TO_CHAR(shinumber) = :input OR customer = :input OR ponumber = :input OR TO_CHAR(lastinvnum) = :input OR UPPER(bilname) LIKE UPPER(''%'' || :input || ''%'')',
+        p_items_per_page => 25
+    );
+    COMMIT;
+END;
+/
+*/
+
+-- ALTERNATIVE: Create separate endpoints for different data types
+
+-- Endpoint 1: For numeric searches
+SELECT * FROM SFLDAT.OESHIH 
+WHERE REGEXP_LIKE(:input, '^[0-9]+$')
+  AND (shiuniq = TO_NUMBER(:input) 
+       OR shinumber = TO_NUMBER(:input) 
+       OR lastinvnum = TO_NUMBER(:input))
+
+-- Endpoint 2: For string searches
+SELECT * FROM SFLDAT.OESHIH 
+WHERE customer = :input 
+   OR ponumber = :input 
+   OR UPPER(bilname) LIKE UPPER('%' || :input || '%')
+
+-- TEST CASES:
+-- 1. :input = '12345' -> Will search numeric fields
+-- 2. :input = 'CUST001' -> Will search string fields
+-- 3. :input = 'John' -> Will search bilname and string fields
+-- 4. :input = NULL or '' -> Returns all records

--- a/high_performance_oeshih.sql
+++ b/high_performance_oeshih.sql
@@ -1,0 +1,164 @@
+-- High Performance OESHIH query solutions
+-- Avoid TO_CHAR() conversions that kill performance
+
+-- PROBLEM: TO_CHAR() prevents index usage and causes full table scans
+-- SOLUTION: Use separate endpoints or smart data type detection
+
+-- SOLUTION 1: Separate endpoints for different data types (BEST PERFORMANCE)
+-- Create different API endpoints based on what you're searching for
+
+-- Endpoint 1: Search by numeric values (shiuniq, shinumber, lastinvnum)
+SELECT * FROM SFLDAT.OESHIH 
+WHERE shiuniq = :input 
+   OR shinumber = :input 
+   OR lastinvnum = :input
+
+-- Endpoint 2: Search by string values (customer, ponumber, bilname)
+SELECT * FROM SFLDAT.OESHIH 
+WHERE customer = :input 
+   OR ponumber = :input 
+   OR UPPER(bilname) LIKE UPPER('%' || :input || '%')
+
+-- SOLUTION 2: Smart input detection with CASE (GOOD PERFORMANCE)
+SELECT * 
+FROM SFLDAT.OESHIH
+WHERE (:input IS NULL OR :input = '')
+   OR (
+       -- If input is numeric, search numeric fields only
+       CASE 
+           WHEN REGEXP_LIKE(:input, '^[0-9]+$') THEN
+               shiuniq = TO_NUMBER(:input) 
+               OR shinumber = TO_NUMBER(:input) 
+               OR lastinvnum = TO_NUMBER(:input)
+           ELSE 0
+       END = 1
+   )
+   OR (
+       -- If input is string, search string fields only
+       customer = :input 
+       OR ponumber = :input 
+       OR UPPER(bilname) LIKE UPPER('%' || :input || '%')
+   )
+
+-- SOLUTION 3: Use UNION ALL for better performance
+SELECT * FROM SFLDAT.OESHIH WHERE shiuniq = :input
+UNION ALL
+SELECT * FROM SFLDAT.OESHIH WHERE shinumber = :input AND shiuniq != :input
+UNION ALL
+SELECT * FROM SFLDAT.OESHIH WHERE lastinvnum = :input AND shiuniq != :input AND shinumber != :input
+UNION ALL
+SELECT * FROM SFLDAT.OESHIH WHERE customer = :input AND shiuniq != :input AND shinumber != :input AND lastinvnum != :input
+UNION ALL
+SELECT * FROM SFLDAT.OESHIH WHERE ponumber = :input AND shiuniq != :input AND shinumber != :input AND lastinvnum != :input AND customer != :input
+UNION ALL
+SELECT * FROM SFLDAT.OESHIH WHERE UPPER(bilname) LIKE UPPER('%' || :input || '%') 
+    AND shiuniq != :input AND shinumber != :input AND lastinvnum != :input AND customer != :input AND ponumber != :input
+WHERE (:input IS NOT NULL AND :input != '')
+
+-- SOLUTION 4: Required indexes for maximum performance
+-- Create these indexes first:
+/*
+CREATE INDEX idx_oeshih_shiuniq ON SFLDAT.OESHIH(shiuniq);
+CREATE INDEX idx_oeshih_shinumber ON SFLDAT.OESHIH(shinumber);
+CREATE INDEX idx_oeshih_lastinvnum ON SFLDAT.OESHIH(lastinvnum);
+CREATE INDEX idx_oeshih_customer ON SFLDAT.OESHIH(customer);
+CREATE INDEX idx_oeshih_ponumber ON SFLDAT.OESHIH(ponumber);
+CREATE INDEX idx_oeshih_bilname_upper ON SFLDAT.OESHIH(UPPER(bilname));
+*/
+
+-- SOLUTION 5: Hybrid approach - Use different strategies based on input
+SELECT * 
+FROM SFLDAT.OESHIH
+WHERE (:input IS NULL OR :input = '')
+   OR (
+       -- For numeric input, use direct numeric comparison
+       CASE 
+           WHEN REGEXP_LIKE(:input, '^[0-9]+$') THEN
+               shiuniq = TO_NUMBER(:input) 
+               OR shinumber = TO_NUMBER(:input) 
+               OR lastinvnum = TO_NUMBER(:input)
+           ELSE 0
+       END = 1
+   )
+   OR (
+       -- For string input, use string comparison
+       customer = :input 
+       OR ponumber = :input 
+       OR UPPER(bilname) LIKE UPPER('%' || :input || '%')
+   )
+
+-- RECOMMENDED ORDS IMPLEMENTATION:
+
+-- Option A: Single endpoint with smart detection
+BEGIN
+    ORDS.DEFINE_HANDLER(
+        p_module_name    => 'salesforceext',
+        p_pattern        => 'sfldat/oeshih',
+        p_method         => 'GET',
+        p_source_type    => ORDS.source_type_collection_feed,
+        p_source         => 'SELECT * FROM SFLDAT.OESHIH WHERE (:input IS NULL OR :input = '''') OR (CASE WHEN REGEXP_LIKE(:input, ''^[0-9]+$'') THEN shiuniq = TO_NUMBER(:input) OR shinumber = TO_NUMBER(:input) OR lastinvnum = TO_NUMBER(:input) ELSE 0 END = 1) OR (customer = :input OR ponumber = :input OR UPPER(bilname) LIKE UPPER(''%'' || :input || ''%''))',
+        p_items_per_page => 25
+    );
+    COMMIT;
+END;
+/
+
+-- Option B: Separate endpoints (BEST PERFORMANCE)
+-- Endpoint 1: Numeric search
+BEGIN
+    ORDS.DEFINE_HANDLER(
+        p_module_name    => 'salesforceext',
+        p_pattern        => 'sfldat/oeshih/numeric',
+        p_method         => 'GET',
+        p_source_type    => ORDS.source_type_collection_feed,
+        p_source         => 'SELECT * FROM SFLDAT.OESHIH WHERE shiuniq = :input OR shinumber = :input OR lastinvnum = :input',
+        p_items_per_page => 25
+    );
+    COMMIT;
+END;
+/
+
+-- Endpoint 2: String search
+BEGIN
+    ORDS.DEFINE_HANDLER(
+        p_module_name    => 'salesforceext',
+        p_pattern        => 'sfldat/oeshih/text',
+        p_method         => 'GET',
+        p_source_type    => ORDS.source_type_collection_feed,
+        p_source         => 'SELECT * FROM SFLDAT.OESHIH WHERE customer = :input OR ponumber = :input OR UPPER(bilname) LIKE UPPER(''%'' || :input || ''%'')',
+        p_items_per_page => 25
+    );
+    COMMIT;
+END;
+/
+
+-- PERFORMANCE OPTIMIZATION TIPS:
+
+-- 1. Create composite indexes for common search patterns
+/*
+CREATE INDEX idx_oeshih_shiuniq_shinumber ON SFLDAT.OESHIH(shiuniq, shinumber);
+CREATE INDEX idx_oeshih_customer_ponumber ON SFLDAT.OESHIH(customer, ponumber);
+*/
+
+-- 2. Use function-based indexes for case-insensitive search
+/*
+CREATE INDEX idx_oeshih_bilname_upper ON SFLDAT.OESHIH(UPPER(bilname));
+*/
+
+-- 3. Consider partitioning for large tables
+/*
+-- Partition by date or other logical criteria
+*/
+
+-- 4. Use hints for specific execution plans
+SELECT /*+ INDEX(oeshih idx_oeshih_shiuniq) */ * 
+FROM SFLDAT.OESHIH
+WHERE shiuniq = :input
+
+-- 5. Cache frequently accessed data
+-- Consider using Oracle Result Cache or application-level caching
+
+-- USAGE EXAMPLES:
+-- For numeric search: /ords/salesforceext/sfldat/oeshih/numeric?input=12345
+-- For text search: /ords/salesforceext/sfldat/oeshih/text?input=CUST001
+-- For smart search: /ords/salesforceext/sfldat/oeshih?input=12345 (auto-detects type)

--- a/oeshih_query_analysis.sql
+++ b/oeshih_query_analysis.sql
@@ -1,0 +1,113 @@
+-- Analysis of the OESHIH query issues and solutions
+
+-- Original query with issues:
+/*
+SELECT * 
+FROM SFLDAT.OESHIH
+WHERE 
+    :input IS NULL
+    OR shiuniq = :input
+    OR shinumber = :input
+    OR LOWER(bilname) LIKE LOWER('%' || :input || '%')
+    OR customer = :input
+    OR ponumber = :input
+    OR lastinvnum = :input
+*/
+
+-- ISSUE 1: Logic Problem - Using OR instead of proper conditional logic
+-- When :input IS NULL, it returns ALL records (which might be intended)
+-- When :input has a value, it returns records matching ANY of the conditions
+-- This means if you search for a customer, it will also return records where that value matches shiuniq, shinumber, etc.
+
+-- ISSUE 2: Empty string handling
+-- The query doesn't handle empty strings properly
+-- When :input = '', it should be treated as NULL
+
+-- ISSUE 3: Performance issue with LOWER() on both sides
+-- Using LOWER() on both sides of LIKE is redundant
+
+-- ISSUE 4: Data type mismatches
+-- Different columns might have different data types
+-- Comparing string input with numeric fields might cause issues
+
+-- CORRECTED VERSION 1: Proper conditional logic with empty string handling
+SELECT * 
+FROM SFLDAT.OESHIH
+WHERE 
+    (:input IS NULL OR :input = '')
+    OR shiuniq = :input
+    OR shinumber = :input
+    OR bilname LIKE '%' || :input || '%'
+    OR customer = :input
+    OR ponumber = :input
+    OR lastinvnum = :input
+
+-- CORRECTED VERSION 2: Case-insensitive search for bilname
+SELECT * 
+FROM SFLDAT.OESHIH
+WHERE 
+    (:input IS NULL OR :input = '')
+    OR shiuniq = :input
+    OR shinumber = :input
+    OR UPPER(bilname) LIKE UPPER('%' || :input || '%')
+    OR customer = :input
+    OR ponumber = :input
+    OR lastinvnum = :input
+
+-- CORRECTED VERSION 3: Handle potential data type issues
+SELECT * 
+FROM SFLDAT.OESHIH
+WHERE 
+    (:input IS NULL OR :input = '')
+    OR TO_CHAR(shiuniq) = :input
+    OR TO_CHAR(shinumber) = :input
+    OR UPPER(bilname) LIKE UPPER('%' || :input || '%')
+    OR customer = :input
+    OR ponumber = :input
+    OR TO_CHAR(lastinvnum) = :input
+
+-- ALTERNATIVE: Using REGEXP_LIKE for more flexible search
+SELECT * 
+FROM SFLDAT.OESHIH
+WHERE 
+    (:input IS NULL OR :input = '')
+    OR TO_CHAR(shiuniq) = :input
+    OR TO_CHAR(shinumber) = :input
+    OR REGEXP_LIKE(bilname, :input, 'i')
+    OR customer = :input
+    OR ponumber = :input
+    OR TO_CHAR(lastinvnum) = :input
+
+-- RECOMMENDED VERSION: Most robust and performant
+SELECT * 
+FROM SFLDAT.OESHIH
+WHERE 
+    (:input IS NULL OR :input = '')
+    OR shiuniq = :input
+    OR shinumber = :input
+    OR UPPER(bilname) LIKE UPPER('%' || :input || '%')
+    OR customer = :input
+    OR ponumber = :input
+    OR lastinvnum = :input
+
+-- For ORDS API, use this in your handler:
+/*
+BEGIN
+    ORDS.DEFINE_HANDLER(
+        p_module_name    => 'salesforceext',
+        p_pattern        => 'sfldat/oeshih',
+        p_method         => 'GET',
+        p_source_type    => ORDS.source_type_collection_feed,
+        p_source         => 'SELECT * FROM SFLDAT.OESHIH WHERE (:input IS NULL OR :input = '''' OR shiuniq = :input OR shinumber = :input OR UPPER(bilname) LIKE UPPER(''%'' || :input || ''%'') OR customer = :input OR ponumber = :input OR lastinvnum = :input)',
+        p_items_per_page => 25
+    );
+    COMMIT;
+END;
+/
+*/
+
+-- Test cases to verify the logic:
+-- 1. :input = NULL or '' -> Returns all records
+-- 2. :input = 'CUST123' -> Returns records where customer = 'CUST123'
+-- 3. :input = 'SHIP001' -> Returns records where shinumber = 'SHIP001'
+-- 4. :input = 'John' -> Returns records where bilname contains 'John' (case-insensitive)

--- a/optimized_oeshih_query.sql
+++ b/optimized_oeshih_query.sql
@@ -1,0 +1,144 @@
+-- Optimized OESHIH query solutions for better performance
+
+-- PROBLEM: Multiple OR conditions cause poor performance
+-- Each OR condition can trigger a separate table scan
+-- LIKE with wildcards prevents index usage
+-- No proper indexing strategy
+
+-- SOLUTION 1: Use UNION ALL for better performance (RECOMMENDED)
+-- This allows Oracle to use indexes on each individual column
+SELECT * FROM SFLDAT.OESHIH WHERE shiuniq = :input
+UNION ALL
+SELECT * FROM SFLDAT.OESHIH WHERE shinumber = :input AND shiuniq != :input
+UNION ALL
+SELECT * FROM SFLDAT.OESHIH WHERE customer = :input AND shiuniq != :input AND shinumber != :input
+UNION ALL
+SELECT * FROM SFLDAT.OESHIH WHERE ponumber = :input AND shiuniq != :input AND shinumber != :input AND customer != :input
+UNION ALL
+SELECT * FROM SFLDAT.OESHIH WHERE lastinvnum = :input AND shiuniq != :input AND shinumber != :input AND customer != :input AND ponumber != :input
+UNION ALL
+SELECT * FROM SFLDAT.OESHIH WHERE UPPER(bilname) LIKE UPPER('%' || :input || '%') 
+    AND shiuniq != :input AND shinumber != :input AND customer != :input AND ponumber != :input AND lastinvnum != :input
+WHERE (:input IS NOT NULL AND :input != '')
+
+-- SOLUTION 2: Use CASE WHEN for conditional logic (Better than OR)
+SELECT * 
+FROM SFLDAT.OESHIH
+WHERE CASE 
+    WHEN :input IS NULL OR :input = '' THEN 1
+    WHEN shiuniq = :input THEN 1
+    WHEN shinumber = :input THEN 1
+    WHEN customer = :input THEN 1
+    WHEN ponumber = :input THEN 1
+    WHEN lastinvnum = :input THEN 1
+    WHEN UPPER(bilname) LIKE UPPER('%' || :input || '%') THEN 1
+    ELSE 0
+END = 1
+
+-- SOLUTION 3: Separate endpoints for different search types (BEST PERFORMANCE)
+-- Create different API endpoints for different search types
+
+-- Endpoint 1: Search by shiuniq (exact match)
+SELECT * FROM SFLDAT.OESHIH WHERE shiuniq = :input
+
+-- Endpoint 2: Search by shinumber (exact match)
+SELECT * FROM SFLDAT.OESHIH WHERE shinumber = :input
+
+-- Endpoint 3: Search by customer (exact match)
+SELECT * FROM SFLDAT.OESHIH WHERE customer = :input
+
+-- Endpoint 4: Search by bilname (partial match)
+SELECT * FROM SFLDAT.OESHIH WHERE UPPER(bilname) LIKE UPPER('%' || :input || '%')
+
+-- SOLUTION 4: Use function-based indexes for better performance
+-- Create these indexes first:
+/*
+CREATE INDEX idx_oeshih_shiuniq ON SFLDAT.OESHIH(shiuniq);
+CREATE INDEX idx_oeshih_shinumber ON SFLDAT.OESHIH(shinumber);
+CREATE INDEX idx_oeshih_customer ON SFLDAT.OESHIH(customer);
+CREATE INDEX idx_oeshih_ponumber ON SFLDAT.OESHIH(ponumber);
+CREATE INDEX idx_oeshih_lastinvnum ON SFLDAT.OESHIH(lastinvnum);
+CREATE INDEX idx_oeshih_bilname_upper ON SFLDAT.OESHIH(UPPER(bilname));
+*/
+
+-- Then use this optimized query:
+SELECT * 
+FROM SFLDAT.OESHIH
+WHERE (:input IS NULL OR :input = '')
+   OR shiuniq = :input
+   OR shinumber = :input
+   OR customer = :input
+   OR ponumber = :input
+   OR lastinvnum = :input
+   OR UPPER(bilname) LIKE UPPER('%' || :input || '%')
+
+-- SOLUTION 5: Use Oracle Text for full-text search (BEST FOR TEXT SEARCH)
+-- First, create a text index:
+/*
+CREATE INDEX oeshih_text_idx ON SFLDAT.OESHIH(bilname) 
+INDEXTYPE IS CTXSYS.CONTEXT;
+*/
+
+-- Then use CONTAINS for text search:
+SELECT * 
+FROM SFLDAT.OESHIH
+WHERE (:input IS NULL OR :input = '')
+   OR shiuniq = :input
+   OR shinumber = :input
+   OR customer = :input
+   OR ponumber = :input
+   OR lastinvnum = :input
+   OR CONTAINS(bilname, :input) > 0
+
+-- SOLUTION 6: Hybrid approach - Use different strategies based on input type
+SELECT * 
+FROM SFLDAT.OESHIH
+WHERE (:input IS NULL OR :input = '')
+   OR (
+       -- For numeric-looking input, search numeric fields first
+       CASE 
+           WHEN REGEXP_LIKE(:input, '^[0-9]+$') THEN
+               shiuniq = :input OR shinumber = :input OR lastinvnum = :input
+           ELSE
+               customer = :input OR ponumber = :input OR UPPER(bilname) LIKE UPPER('%' || :input || '%')
+       END
+   )
+
+-- RECOMMENDED IMPLEMENTATION FOR ORDS:
+-- Use separate endpoints for better performance
+
+-- Endpoint 1: Search by exact match (fastest)
+BEGIN
+    ORDS.DEFINE_HANDLER(
+        p_module_name    => 'salesforceext',
+        p_pattern        => 'sfldat/oeshih/exact',
+        p_method         => 'GET',
+        p_source_type    => ORDS.source_type_collection_feed,
+        p_source         => 'SELECT * FROM SFLDAT.OESHIH WHERE shiuniq = :input OR shinumber = :input OR customer = :input OR ponumber = :input OR lastinvnum = :input',
+        p_items_per_page => 25
+    );
+    COMMIT;
+END;
+/
+
+-- Endpoint 2: Search by text (slower but necessary)
+BEGIN
+    ORDS.DEFINE_HANDLER(
+        p_module_name    => 'salesforceext',
+        p_pattern        => 'sfldat/oeshih/text',
+        p_method         => 'GET',
+        p_source_type    => ORDS.source_type_collection_feed,
+        p_source         => 'SELECT * FROM SFLDAT.OESHIH WHERE UPPER(bilname) LIKE UPPER(''%'' || :input || ''%'')',
+        p_items_per_page => 25
+    );
+    COMMIT;
+END;
+/
+
+-- PERFORMANCE TIPS:
+-- 1. Create indexes on all search columns
+-- 2. Use separate endpoints for different search types
+-- 3. Consider Oracle Text for full-text search
+-- 4. Use UNION ALL instead of OR when possible
+-- 5. Limit result sets with pagination
+-- 6. Consider caching frequently searched values

--- a/ords_api_solution.sql
+++ b/ords_api_solution.sql
@@ -1,0 +1,59 @@
+-- Oracle ADW ORDS API Solution for OEINVH table
+-- This provides the correct SQL logic for handling optional parameters
+
+-- Option 1: Using CASE WHEN for conditional filtering
+SELECT * 
+FROM SFLDAT.OEINVH 
+WHERE (CASE 
+    WHEN :invuniq IS NOT NULL AND :invuniq != '' THEN 
+        CASE WHEN invuniq = :invuniq THEN 1 ELSE 0 END
+    WHEN :customer IS NOT NULL AND :customer != '' THEN 
+        CASE WHEN customer = :customer THEN 1 ELSE 0 END
+    ELSE 1  -- Return all records when no parameters provided
+END) = 1;
+
+-- Option 2: Using NVL with proper conditional logic (Recommended)
+SELECT * 
+FROM SFLDAT.OEINVH 
+WHERE (:invuniq IS NULL OR :invuniq = '' OR invuniq = :invuniq)
+  AND (:customer IS NULL OR :customer = '' OR customer = :customer);
+
+-- Option 3: Most explicit and readable approach
+SELECT * 
+FROM SFLDAT.OEINVH 
+WHERE (:invuniq IS NULL OR :invuniq = '' OR invuniq = :invuniq)
+  AND (:customer IS NULL OR :customer = '' OR customer = :customer);
+
+-- For ORDS REST API, you would use this in your handler:
+/*
+CREATE OR REPLACE PROCEDURE get_oeinvh(
+    p_invuniq IN VARCHAR2 DEFAULT NULL,
+    p_customer IN VARCHAR2 DEFAULT NULL,
+    p_result OUT SYS_REFCURSOR
+) AS
+BEGIN
+    OPEN p_result FOR
+        SELECT * 
+        FROM SFLDAT.OEINVH 
+        WHERE (p_invuniq IS NULL OR p_invuniq = '' OR invuniq = p_invuniq)
+          AND (p_customer IS NULL OR p_customer = '' OR customer = p_customer);
+END;
+/
+*/
+
+-- Example ORDS handler configuration:
+/*
+BEGIN
+    ORDS.DEFINE_HANDLER(
+        p_module_name    => 'salesforceext',
+        p_pattern        => 'sfldat/oeinvh',
+        p_method         => 'GET',
+        p_source_type    => ORDS.source_type_collection_feed,
+        p_source         => 'SELECT * FROM SFLDAT.OEINVH WHERE (:invuniq IS NULL OR :invuniq = '''' OR invuniq = :invuniq) AND (:customer IS NULL OR :customer = '''' OR customer = :customer)',
+        p_items_per_page => 25
+    );
+    
+    COMMIT;
+END;
+/
+*/

--- a/ords_oeinvh_setup.sql
+++ b/ords_oeinvh_setup.sql
@@ -1,0 +1,111 @@
+-- Complete ORDS Setup for OEINVH API Endpoint
+-- This script sets up the REST API endpoint with proper parameter handling
+
+-- Step 1: Create the module if it doesn't exist
+BEGIN
+    ORDS.DEFINE_MODULE(
+        p_module_name    => 'salesforceext',
+        p_base_path      => 'salesforceext/',
+        p_items_per_page => 25,
+        p_status         => 'PUBLISHED',
+        p_comments       => 'Salesforce External API Module'
+    );
+    COMMIT;
+EXCEPTION
+    WHEN OTHERS THEN
+        -- Module might already exist, continue
+        NULL;
+END;
+/
+
+-- Step 2: Create the template for the OEINVH endpoint
+BEGIN
+    ORDS.DEFINE_TEMPLATE(
+        p_module_name    => 'salesforceext',
+        p_pattern        => 'sfldat/oeinvh',
+        p_priority       => 0,
+        p_etag_type      => 'HASH',
+        p_etag_query     => NULL,
+        p_comments       => 'OEINVH table endpoint with optional filtering'
+    );
+    COMMIT;
+EXCEPTION
+    WHEN OTHERS THEN
+        -- Template might already exist, continue
+        NULL;
+END;
+/
+
+-- Step 3: Define the GET handler with proper parameter handling
+BEGIN
+    ORDS.DEFINE_HANDLER(
+        p_module_name    => 'salesforceext',
+        p_pattern        => 'sfldat/oeinvh',
+        p_method         => 'GET',
+        p_source_type    => ORDS.source_type_collection_feed,
+        p_source         => 'SELECT * FROM SFLDAT.OEINVH WHERE (:invuniq IS NULL OR :invuniq = '''' OR invuniq = :invuniq) AND (:customer IS NULL OR :customer = '''' OR customer = :customer)',
+        p_items_per_page => 25,
+        p_comments       => 'Get OEINVH records with optional filtering by invuniq or customer'
+    );
+    COMMIT;
+EXCEPTION
+    WHEN OTHERS THEN
+        -- Handler might already exist, drop and recreate
+        ORDS.DELETE_HANDLER(
+            p_module_name => 'salesforceext',
+            p_pattern     => 'sfldat/oeinvh',
+            p_method      => 'GET'
+        );
+        
+        ORDS.DEFINE_HANDLER(
+            p_module_name    => 'salesforceext',
+            p_pattern        => 'sfldat/oeinvh',
+            p_method         => 'GET',
+            p_source_type    => ORDS.source_type_collection_feed,
+            p_source         => 'SELECT * FROM SFLDAT.OEINVH WHERE (:invuniq IS NULL OR :invuniq = '''' OR invuniq = :invuniq) AND (:customer IS NULL OR :customer = '''' OR customer = :customer)',
+            p_items_per_page => 25,
+            p_comments       => 'Get OEINVH records with optional filtering by invuniq or customer'
+        );
+        COMMIT;
+END;
+/
+
+-- Step 4: Enable the module
+BEGIN
+    ORDS.ENABLE_OBJECT(
+        p_enabled      => TRUE,
+        p_schema       => 'SFLDAT',
+        p_object       => 'OEINVH',
+        p_object_type  => 'TABLE',
+        p_object_alias => 'oeinvh'
+    );
+    COMMIT;
+EXCEPTION
+    WHEN OTHERS THEN
+        -- Object might already be enabled, continue
+        NULL;
+END;
+/
+
+-- Step 5: Grant necessary privileges (run as DBA or schema owner)
+-- GRANT SELECT ON SFLDAT.OEINVH TO ORDS_PUBLIC_USER;
+
+-- Verification queries
+-- Check if the endpoint is properly configured
+SELECT 
+    m.module_name,
+    t.pattern,
+    h.method,
+    h.source_type,
+    h.source
+FROM user_ords_modules m
+JOIN user_ords_templates t ON m.module_id = t.module_id
+JOIN user_ords_handlers h ON t.template_id = h.template_id
+WHERE m.module_name = 'salesforceext'
+  AND t.pattern = 'sfldat/oeinvh';
+
+-- Test the endpoint URLs:
+-- 1. Get all records: https://testitrack.servicefoods.co.nz/ords/salesforceext/sfldat/oeinvh
+-- 2. Filter by invuniq: https://testitrack.servicefoods.co.nz/ords/salesforceext/sfldat/oeinvh?invuniq=YOUR_INVUNIQ_VALUE
+-- 3. Filter by customer: https://testitrack.servicefoods.co.nz/ords/salesforceext/sfldat/oeinvh?customer=YOUR_CUSTOMER_VALUE
+-- 4. Filter by both: https://testitrack.servicefoods.co.nz/ords/salesforceext/sfldat/oeinvh?invuniq=YOUR_INVUNIQ_VALUE&customer=YOUR_CUSTOMER_VALUE

--- a/query_analysis.sql
+++ b/query_analysis.sql
@@ -1,0 +1,78 @@
+-- Analysis of the OEINVD query issues and solutions
+
+-- Original query with issues:
+/*
+SELECT * 
+FROM SFLDAT.OEINVD
+WHERE 
+    (:invuniq IS NULL OR invuniq = :invuniq)
+    AND (:item IS NULL OR item = :item)
+    AND (:desc IS NULL OR LOWER(desc) LIKE LOWER('%' || :desc || '%'))
+*/
+
+-- ISSUE 1: 'desc' is a reserved keyword in Oracle
+-- Oracle reserves 'desc' for ORDER BY DESC clause
+-- This can cause syntax errors or unexpected behavior
+
+-- ISSUE 2: Empty string handling
+-- The query doesn't handle empty strings properly
+-- When :invuniq = '' or :item = '' or :desc = '', it should be treated as NULL
+
+-- ISSUE 3: Case sensitivity in LIKE comparison
+-- Using LOWER() on both sides is redundant and can impact performance
+
+-- CORRECTED VERSION 1: Handle reserved keyword and empty strings
+SELECT * 
+FROM SFLDAT.OEINVD
+WHERE 
+    (:invuniq IS NULL OR :invuniq = '' OR invuniq = :invuniq)
+    AND (:item IS NULL OR :item = '' OR item = :item)
+    AND (:desc IS NULL OR :desc = '' OR LOWER("desc") LIKE LOWER('%' || :desc || '%'))
+
+-- CORRECTED VERSION 2: Better performance with proper indexing
+SELECT * 
+FROM SFLDAT.OEINVD
+WHERE 
+    (:invuniq IS NULL OR :invuniq = '' OR invuniq = :invuniq)
+    AND (:item IS NULL OR :item = '' OR item = :item)
+    AND (:desc IS NULL OR :desc = '' OR "desc" LIKE '%' || :desc || '%')
+
+-- CORRECTED VERSION 3: Case-insensitive search with better performance
+SELECT * 
+FROM SFLDAT.OEINVD
+WHERE 
+    (:invuniq IS NULL OR :invuniq = '' OR invuniq = :invuniq)
+    AND (:item IS NULL OR :item = '' OR item = :item)
+    AND (:desc IS NULL OR :desc = '' OR UPPER("desc") LIKE UPPER('%' || :desc || '%'))
+
+-- ALTERNATIVE: Using REGEXP_LIKE for more flexible search
+SELECT * 
+FROM SFLDAT.OEINVD
+WHERE 
+    (:invuniq IS NULL OR :invuniq = '' OR invuniq = :invuniq)
+    AND (:item IS NULL OR :item = '' OR item = :item)
+    AND (:desc IS NULL OR :desc = '' OR REGEXP_LIKE("desc", :desc, 'i'))
+
+-- RECOMMENDED VERSION: Most robust and performant
+SELECT * 
+FROM SFLDAT.OEINVD
+WHERE 
+    (:invuniq IS NULL OR :invuniq = '' OR invuniq = :invuniq)
+    AND (:item IS NULL OR :item = '' OR item = :item)
+    AND (:desc IS NULL OR :desc = '' OR "desc" LIKE '%' || :desc || '%')
+
+-- For ORDS API, use this in your handler:
+/*
+BEGIN
+    ORDS.DEFINE_HANDLER(
+        p_module_name    => 'salesforceext',
+        p_pattern        => 'sfldat/oeinvd',
+        p_method         => 'GET',
+        p_source_type    => ORDS.source_type_collection_feed,
+        p_source         => 'SELECT * FROM SFLDAT.OEINVD WHERE (:invuniq IS NULL OR :invuniq = '''' OR invuniq = :invuniq) AND (:item IS NULL OR :item = '''' OR item = :item) AND (:desc IS NULL OR :desc = '''' OR "desc" LIKE ''%'' || :desc || ''%'')',
+        p_items_per_page => 25
+    );
+    COMMIT;
+END;
+/
+*/


### PR DESCRIPTION
Implement an Oracle ORDS API endpoint for `SFLDAT.OEINVH` to support optional filtering by `invuniq` or `customer` and retrieve all records when no parameters are provided.

The original SQL query used `OR` logic, which meant that if any parameter was provided, it would return records matching either condition, preventing the desired behavior of returning all records when no parameters were supplied or filtering specifically by one parameter. The updated SQL uses `AND` logic with `IS NULL OR = ''` checks to correctly handle optional parameters, allowing the API to return all records by default and filter precisely when parameters are present.

---
<a href="https://cursor.com/background-agent?bcId=bc-ac047237-b8f6-4d58-a6e0-0832bbb1f3e9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-ac047237-b8f6-4d58-a6e0-0832bbb1f3e9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>